### PR TITLE
Fixed crash due to depending on default

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -4,5 +4,5 @@ description=Overhead wires supports overhead wires over the Advtrains railways.
 author=MatyasP
 version=10105
 
-depends=
+depends=default
 optional_depends=screwdriver, advtrains_moreslopes


### PR DESCRIPTION
The game would immediately crash when starting with this mod because the mod uses default for sounds, but doesn't list default as a dependency (I'm using Luanti 5.11). This pull request adds default to the dependencies to fix the crash.